### PR TITLE
Fix duplicate issues being created

### DIFF
--- a/__tests__/trivy.test.ts
+++ b/__tests__/trivy.test.ts
@@ -198,6 +198,8 @@ describe('Trivy scan', () => {
 });
 
 describe('Parse', () => {
+  const image: string = 'alpine:3.10';
+
   test('the result without vulnerabilities', () => {
     const vulnerabilities: Vulnerability[] = [
       {
@@ -205,7 +207,7 @@ describe('Parse', () => {
         Vulnerabilities: null,
       },
     ];
-    const result = trivy.parse(vulnerabilities);
+    const result = trivy.parse(image, vulnerabilities);
     expect(result).toBe('');
   });
 
@@ -248,10 +250,11 @@ describe('Parse', () => {
         ],
       },
     ];
-    const result = trivy.parse(vulnerabilities);
+    const result = trivy.parse(image, vulnerabilities);
     expect(result).toMatch(
       /\|Title\|Severity\|CVE\|Package Name\|Installed Version\|Fixed Version\|References\|/
     );
+    expect(result).toContain(image);
   });
 });
 

--- a/__tests__/trivy.test.ts
+++ b/__tests__/trivy.test.ts
@@ -36,7 +36,7 @@ describe('getDownloadUrl', () => {
     const os = 'Linux';
     const result = await downloader['getDownloadUrl'](version, os);
     expect(result).toMatch(
-      /releases\/download\/v[0-9]\.[0-9]\.[0-9]\/trivy_[0-9]\.[0-9]\.[0-9]_Linux-64bit\.tar\.gz$/
+      /releases\/download\/v[0-9]+\.[0-9]+\.[0-9]+\/trivy_[0-9]+\.[0-9]+\.[0-9]+_Linux-64bit\.tar\.gz$/
     );
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6572,7 +6572,7 @@ function run() {
         ${result}`);
                 return;
             }
-            const issueContent = trivy.parse(result);
+            const issueContent = trivy.parse(image, result);
             if (issueContent === '') {
                 core.info('Vulnerabilities were not found.\nYour maintenance looks good 👍');
                 return;
@@ -13337,7 +13337,7 @@ class Trivy {
       error: ${result.error}
     `);
     }
-    parse(vulnerabilities) {
+    parse(image, vulnerabilities) {
         let issueContent = '';
         for (const vuln of vulnerabilities) {
             if (vuln.Vulnerabilities === null)
@@ -13361,7 +13361,7 @@ class Trivy {
             }
             issueContent += `${vulnTable}\n\n`;
         }
-        return issueContent;
+        return issueContent ? `_(image scanned: \`${image}\`)_\n\n${issueContent}` : issueContent;
     }
     validateOption(option) {
         this.validateSeverity(option.severity.split(','));

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ async function run() {
       return;
     }
 
-    const issueContent: string = trivy.parse(result as Vulnerability[]);
+    const issueContent: string = trivy.parse(image, result as Vulnerability[]);
 
     if (issueContent === '') {
       core.info(

--- a/src/trivy.ts
+++ b/src/trivy.ts
@@ -164,7 +164,7 @@ export class Trivy {
     `);
   }
 
-  public parse(vulnerabilities: Vulnerability[]): string {
+  public parse(image: string, vulnerabilities: Vulnerability[]): string {
     let issueContent: string = '';
 
     for (const vuln of vulnerabilities) {
@@ -191,7 +191,8 @@ export class Trivy {
       }
       issueContent += `${vulnTable}\n\n`;
     }
-    return issueContent;
+
+    return issueContent ? `_(image scanned: \`${image}\`)_\n\n${issueContent}` : issueContent;
   }
 
   private validateOption(option: TrivyOption): void {


### PR DESCRIPTION
We rely on the `image` name (e.g. `rasa/rasa:latest-scanned`) to be present in the body of the issue being created by `gitrivy`. If it's not present, duplicate issues will be created (cf. what happened on `RasaHQ/rasa`)